### PR TITLE
Add "types" to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "./lib/cjs/exports.js",
   "module": "./lib/mjs/exports.mjs",
   "exports": {
+    "types": "./lib/exports.d.ts",
     "import": "./lib/mjs/exports.mjs",
     "require": "./lib/cjs/exports.js"
   },


### PR DESCRIPTION
This seems mandatory for `"moduleResolution": "bundle"` TS config option.

The same is true for other packages.